### PR TITLE
Fix for error when trying to save form with select multiple.

### DIFF
--- a/django_batch_uploader/static/batch/js/jquery.batchupload.js
+++ b/django_batch_uploader/static/batch/js/jquery.batchupload.js
@@ -1114,7 +1114,14 @@ UploadableItem.prototype.start_upload = function(form_url, form_method, filename
 
     var form_data = new FormData();
     for (key in this.data) {
-        form_data.append(key, this.data[key]);
+        const value = this.data[key];
+        if (Array.isArray(value)) {
+        value.forEach(val => {
+          form_data.append(`${key}`, val);
+        });
+      } else {
+        form_data.append(key, value);
+      }
     }
 
     this.failed_status = null;


### PR DESCRIPTION
Okay so this drove me a little crazy for a couple of hours. I added a ManyToMany field in my Image Model, where a user could select multiple users. The field is not required. However whenever I tried to leave the field empty and upload I kept getting 

` "" is not a valid value for a primary key.`

Some experimenting showed that if I selected ONE item, it would upload fine, but then if I tried to select 2+ items, I'd get 

`"2,3" is not a valid value for a primary key.`

Long story short, the error was from the `start_upload` function, when the field values are attached to `new FormData()`. Apparently FormaData converts the array of values sent by the `select multiple` field to a string-like value.

``` javascript
// this
['2', '3']
// becomes 
['2,3']
// once appended
```
To circumvent this I changed the code to check for arrays.

``` javascript
    var form_data = new FormData();
    for (key in this.data) {
        const value = this.data[key];
        if (Array.isArray(value)) {
          value.forEach(val => {
            form_data.append(`${key}`, val);
        });
      } else {
          form_data.append(key, value);
      }
    }
```


